### PR TITLE
Add MQTT client disconnect detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,3 +3,11 @@ TeleQTT
 
 This easy script publish to MQTT the value from a serial teleinfo modem located at /dev/teleinfo.
 The labels are pushed to the EDF/<label> at local MQTT server.
+
+Imports
+=======
+The mosquitto library used for the MQTT client may not be available on your default installation.  It can be installed with pip like this:
+`pip install mosquitto`
+
+If you are running on a Raspberry Pi and need to install pip, you can do it with this:
+`sudo apt-get install python-setuptools && sudo easy_install pip`

--- a/README.md
+++ b/README.md
@@ -11,3 +11,14 @@ The mosquitto library used for the MQTT client may not be available on your defa
 
 If you are running on a Raspberry Pi and need to install pip, you can do it with this:
 `sudo apt-get install python-setuptools && sudo easy_install pip`
+
+Issues
+======
+Screen is used to run the background service for the Python code. There is a known bug with screen where it will not be able to run after a reboot and will complain about not having appropriate permissions.
+    $ screen
+    Cannot make directory '/var/run/screen': Permission denied
+
+Running screen as sudo once after a reboot makes with work properly.  More information here:
+https://bugs.launchpad.net/ubuntu/+source/screen/+bug/312259
+
+

--- a/README.md
+++ b/README.md
@@ -7,18 +7,10 @@ The labels are pushed to the EDF/<label> at local MQTT server.
 Imports
 =======
 The mosquitto library used for the MQTT client may not be available on your default installation.  It can be installed with pip like this:
+
 `pip install mosquitto`
 
 If you are running on a Raspberry Pi and need to install pip, you can do it with this:
+
 `sudo apt-get install python-setuptools && sudo easy_install pip`
-
-Issues
-======
-Screen is used to run the background service for the Python code. There is a known bug with screen where it will not be able to run after a reboot and will complain about not having appropriate permissions.
-    $ screen
-    Cannot make directory '/var/run/screen': Permission denied
-
-Running screen as sudo once after a reboot makes with work properly.  More information here:
-https://bugs.launchpad.net/ubuntu/+source/screen/+bug/312259
-
 

--- a/TeleQTT.py
+++ b/TeleQTT.py
@@ -4,7 +4,7 @@ import os
 import teleinfo
 from serial import SerialException
 
-broker = "localhost"
+broker = "broker"
 port = 1883
 
 def on_connect(mosq, obj, rc):

--- a/TeleQTT.py
+++ b/TeleQTT.py
@@ -18,6 +18,10 @@ def on_connect(mosq, obj, rc):
 def on_publish(mosq, obj, mid):
     print("Message "+str(mid)+" published.")
  
+def on_disconnect(mosq, obj, rc):
+    if rc != 0:
+        print("Unexpected disconnection.")
+
  
 #called on exit
 #close serial, disconnect MQTT
@@ -43,6 +47,7 @@ try:
 #attach MQTT callbacks
     mqttc.on_connect = on_connect
     mqttc.on_publish = on_publish
+    mqttc.on_disconnect = on_disconnect
 
 #connect to broker
     mqttc.connect(broker, port, 60, True)

--- a/TeleQTT.py
+++ b/TeleQTT.py
@@ -3,6 +3,7 @@ import mosquitto
 import os
 import teleinfo
 from serial import SerialException
+from socket import gethostname
 
 broker = "broker"
 port = 1883
@@ -50,7 +51,7 @@ try:
         line = ti.read()
         if line is not None:
             for serEtiquette, serValue in line.items():
-                mqttc.publish("EDF/"+serEtiquette, serValue)
+                mqttc.publish(gethostname()+"/ENERGY/TeleInfo/"+serEtiquette, serValue)
 except (SerialException):
     print "Serial Exception"
 #    pass

--- a/TeleQTT.py
+++ b/TeleQTT.py
@@ -51,7 +51,7 @@ try:
         line = ti.read()
         if line is not None:
             for serEtiquette, serValue in line.items():
-                mqttc.publish(gethostname()+"/ENERGY/TeleInfo/"+serEtiquette, serValue)
+                mqttc.publish("/"+gethostname()+"/TELEQTT-V1/"+serEtiquette, serValue)
 except (SerialException):
     print "Serial Exception"
 #    pass

--- a/teleinfo.init
+++ b/teleinfo.init
@@ -7,7 +7,7 @@ set -e
 NAME=teleinfo
 PIDFILE=/var/run/$NAME.pid
 #This is the command to be run, give the full pathname
-DAEMON_OPTS="-d -m -S $NAME /home/username/TeleQTT/TeleQTT.py &> /dev/null"
+DAEMON_OPTS="-d -m -S $NAME /opt/TeleQTT/TeleQTT.py &> /dev/null"
 DAEMON=/usr/bin/screen
  
 export PATH="${PATH:+$PATH:}/usr/sbin:/sbin"

--- a/teleinfo.sh
+++ b/teleinfo.sh
@@ -1,0 +1,61 @@
+#!/bin/sh
+
+### BEGIN INIT INFO
+# Provides:          myservice
+# Required-Start:    $remote_fs $syslog
+# Required-Stop:     $remote_fs $syslog
+# Default-Start:     2 3 4 5
+# Default-Stop:      0 1 6
+# Short-Description: Put a short description of the service here
+# Description:       Put a long description of the service here
+### END INIT INFO
+
+# Change the next 3 lines to suit where you install your script and what you want to call it
+DIR=/opt/TeleQTT
+DAEMON=$DIR/TeleQTT.py
+DAEMON_NAME=teleinfo
+
+# Add any command line options for your daemon here
+DAEMON_OPTS=""
+
+# This next line determines what user the script runs as.
+# Root generally not recommended but necessary if you are using the Raspberry Pi GPIO from Python.
+DAEMON_USER=root
+
+# The process ID of the script when it runs is stored here:
+PIDFILE=/var/run/$DAEMON_NAME.pid
+
+. /lib/lsb/init-functions
+
+do_start () {
+    log_daemon_msg "Starting system $DAEMON_NAME daemon"
+    start-stop-daemon --start --background --pidfile $PIDFILE --make-pidfile --user $DAEMON_USER --chuid $DAEMON_USER --startas $DAEMON -- $DAEMON_OPTS
+    log_end_msg $?
+}
+do_stop () {
+    log_daemon_msg "Stopping system $DAEMON_NAME daemon"
+    start-stop-daemon --stop --pidfile $PIDFILE --retry 10
+    log_end_msg $?
+}
+
+case "$1" in
+
+    start|stop)
+        do_${1}
+        ;;
+
+    restart|reload|force-reload)
+        do_stop
+        do_start
+        ;;
+
+    status)
+        status_of_proc "$DAEMON_NAME" "$DAEMON" && exit 0 || exit $?
+        ;;
+    *)
+        echo "Usage: /etc/init.d/$DAEMON_NAME {start|stop|restart|status}"
+        exit 1
+        ;;
+
+esac
+exit 0

--- a/teleinfo.sh
+++ b/teleinfo.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 ### BEGIN INIT INFO
-# Provides:          teleinfo
+# Provides:          TeleQTT
 # Required-Start:    $remote_fs $syslog
 # Required-Stop:     $remote_fs $syslog
 # Default-Start:     2 3 4 5
@@ -13,7 +13,7 @@
 # Change the next 3 lines to suit where you install your script and what you want to call it
 DIR=/opt/TeleQTT
 DAEMON=$DIR/TeleQTT.py
-DAEMON_NAME=teleinfo
+DAEMON_NAME=TeleQTT
 
 # Add any command line options for your daemon here
 DAEMON_OPTS=""

--- a/teleinfo.sh
+++ b/teleinfo.sh
@@ -1,13 +1,13 @@
 #!/bin/sh
 
 ### BEGIN INIT INFO
-# Provides:          myservice
+# Provides:          teleinfo
 # Required-Start:    $remote_fs $syslog
 # Required-Stop:     $remote_fs $syslog
 # Default-Start:     2 3 4 5
 # Default-Stop:      0 1 6
-# Short-Description: Put a short description of the service here
-# Description:       Put a long description of the service here
+# Short-Description: Reads data from ERDF meter using Python script
+# Description:       Reads electricity meter data from ERDF meters with a TeleInformation modem
 ### END INIT INFO
 
 # Change the next 3 lines to suit where you install your script and what you want to call it


### PR DESCRIPTION
Sorry R.B.... but I can't seem to figure out how to do this PR properly to just reference my one commit. c0d91e1
When the MQTT broker connection is lost, the TeleQTT Python client just loses the connection and then finishes its execution.
I added disconnection detection here that for now only prints a message stating that the connection was lost as a first step, but ideally the idea is to wait awhile and attempt a reconnection.
