### PR TITLE
Handle new paho-mqtt, uses command line params

### DIFF
--- a/TeleQTT.py
+++ b/TeleQTT.py
@@ -75,10 +75,6 @@ try:
         line = ti.read()
         if line is not None:
             for serEtiquette, serValue in line.items():
-                try:
-                    serValue = int(serValue)
-                except:
-                    pass
                 mqttc.publish(options.mqtt_base_topic+serEtiquette, serValue)
 except (SerialException):
     print "Serial Exception"

--- a/TeleQTT.py
+++ b/TeleQTT.py
@@ -1,13 +1,25 @@
 #!/usr/bin/env python
-import mosquitto
+
+# Handle the new paho naming for Mosquitto lib
+try:
+    import mosquitto
+    mqtt_version = "mosquitto"
+except:
+    import paho.mqtt.client as paho
+    mqtt_version = "paho"
+
 import os
 import teleinfo
 from serial import SerialException
+import optparse
 
-broker = "localhost"
-port = 1883
+parser = optparse.OptionParser(description="Serial to MQTT teleinfo interface")
+parser.add_option("-b", "--mqtt-broker-host", help=u"Host name/address for MQTT broker, default = localhost", dest="mqtt_host", default="localhost")
+parser.add_option("-p", "--mqtt-broker-port", help=u"Port for MQTT broker, default = 1883",  dest="mqtt_port", default=1883)
+parser.add_option("-t", "--mqtt-base-topic", help=u"Base toic for published messages, default = EDF/",  dest="mqtt_base_topic", default="EDF/")
+(options, args) = parser.parse_args()
 
-def on_connect(mosq, obj, rc):
+def on_connect(mosq, obj, flags, rc):
     if rc == 0:
     #rc 0 successful connect
         print "Connected"
@@ -41,7 +53,10 @@ except:
 try:
     mypid = os.getpid()
     client_uniq = "RB_EDF"
-    mqttc = mosquitto.Mosquitto(client_uniq)
+    try:
+        mqttc = mosquitto.Mosquitto(client_uniq)
+    except:
+        mqttc = paho.Client(client_uniq)
 
 #attach MQTT callbacks
     mqttc.on_connect = on_connect
@@ -49,13 +64,22 @@ try:
     mqttc.on_disconnect = on_disconnect
 
 #connect to broker
-    mqttc.connect(broker, port, 60, True)
+    if mqtt_version == "mosquitto":
+        mqttc.connect(options.mqtt_host, options.mqtt_port, 60, True)
+    elif mqtt_version == "paho":
+        mqttc.connect(options.mqtt_host, options.mqtt_port, 60)
+    else:
+        raise RuntimeError("Unknown MQTT lib")
  
     while mqttc.loop() == 0:
         line = ti.read()
         if line is not None:
             for serEtiquette, serValue in line.items():
-                mqttc.publish("EDF/"+serEtiquette, serValue)
+                try:
+                    serValue = int(serValue)
+                except:
+                    pass
+                mqttc.publish(options.mqtt_base_topic+serEtiquette, serValue)
 except (SerialException):
     print "Serial Exception"
 #    pass


### PR DESCRIPTION
Also remove leading zeroes for numeric values
Should be backward compatible, but I couldn't test it against the older mosquitto lib